### PR TITLE
Put the vdsl2 overhead keywords on solid theoretical footing

### DIFF
--- a/tc/q_cake.c
+++ b/tc/q_cake.c
@@ -241,12 +241,24 @@ static int cake_parse_opt(struct qdisc_util *qu, int argc, char **argv,
 		/* Typical VDSL2 framing schemes, both over PTM */
 		/* PTM has 64b/65b coding which absorbs some bandwidth */
 		} else if (strcmp(*argv, "pppoe-ptm") == 0) {
+			/* 
+			 * 2B PPP + 6B PPPoE + 6B dest MAC + 6B src MAC 
+			 * + 2B ethertype + 4B Frame Check Sequence
+			 * + 1B Start of Frame (S) + 1B End of Frame (Ck) 
+			 * + 2B TC-CRC (PTM-FCS) = 30B
+			 */
 			atm = 2;
-			overhead += 27;
+			overhead += 30;
 			overhead_set = true;
 		} else if (strcmp(*argv, "bridged-ptm") == 0) {
+			/* 
+			 * 6B dest MAC + 6B src MAC + 2B ethertype 
+			 * + 4B Frame Check Sequence
+			 * + 1B Start of Frame (S) + 1B End of Frame (Ck) 
+			 * + 2B TC-CRC (PTM-FCS) = 22B
+			 */
 			atm = 2;
-			overhead += 19;
+			overhead += 22;
 			overhead_set = true;
 
 		} else if (strcmp(*argv, "via-ethernet") == 0) {


### PR DESCRIPTION
Looking at ITU and IEEE vdls2 specifications it becomes clear that the
following calculations should be correct for:
pppoe-ptm:
	2B PPP + 6B PPPoE + 6B dest MAC + 6B src MAC
	+ 2B ethertype + 4B Frame Check Sequence
	+ 1B Start of Frame (S) + 1B End of Frame (Ck)
	+ 2B TC-CRC (PTM-FCS)
	TOTAL = 30B

bridged-ptm:
	6B dest MAC + 6B src MAC + 2B ethertype.
	+ 4B Frame Check Sequence
	+ 1B Start of Frame (S) + 1B End of Frame (Ck)
	+ 2B TC-CRC (PTM-FCS)
	TOTAL = 22B

The old values of 27 and 19 do not make much sense in the light of the
relevant standards documents (like ITU 992.3 Annex N
and IEEE 802.3 61.3).

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>