### PR TITLE
Use correct contributor name in man page

### DIFF
--- a/man/man8/tc-cake.8
+++ b/man/man8/tc-cake.8
@@ -671,8 +671,8 @@ qdisc cake 8007: root refcnt 6 bandwidth 9500Kbit diffserv3 triple-isolate rtt 1
 
 .SH AUTHORS
 Cake's principal author is Jonathan Morton, with contributions from
-Kevin Darbyshire-Bryant, Toke Høiland-Jørgensen, Sebastian Moeller,
-Ryan Mounce, Guido Sarducci, Dean Scarff, Nils Andreas Svee, and Dave Täht.
+Tony Ambardar, Kevin Darbyshire-Bryant, Toke Høiland-Jørgensen,
+Sebastian Moeller, Ryan Mounce, Dean Scarff, Nils Andreas Svee, and Dave Täht.
 
 This manual page was written by Loganaden Velvindron. Please report corrections
 to the Linux Networking mailing list <netdev@vger.kernel.org>.


### PR DESCRIPTION
My changes from https://github.com/dtaht/sch_cake/pull/33 were merged without a Signed-off line, and somehow my Github pseudonym worked its way into change logs and finally this man page. This fixes it and preserves the alphabetical order.

@dtaht Could you please update my name in any related commit messages? I also omitted a copyright from the same PR, and am wondering if it's an issue for upstream submission?
